### PR TITLE
Refactor navigation and add buying guide data

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+
+const AboutPage: FC = () => {
+  return (
+    <section className="px-4 py-16 max-w-3xl mx-auto text-slate-600 dark:text-slate-300">
+      <h1 className="text-4xl font-bold text-center mb-8 text-slate-900 dark:text-slate-100">About Habrio</h1>
+      <p className="mb-6">
+        Habrio is your trusted companion for making informed purchases. We provide detailed ‘How to Buy’ guides and curated product recommendations to help you shop smarter and buy with confidence.
+      </p>
+      <div className="space-y-4 mb-8">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">How It Works</h2>
+        <ol className="list-decimal pl-5 space-y-2">
+          <li>
+            <span className="font-semibold">Browse Categories:</span> Choose a product category you’re interested in, such as Electronics or Home &amp; Garden.
+          </li>
+          <li>
+            <span className="font-semibold">Read Guides:</span> Dive into our “How to Buy” guides to learn what factors matter for your purchase.
+          </li>
+          <li>
+            <span className="font-semibold">Get Recommendations:</span> Answer a couple of quick questions and see product suggestions across Budget, Mid-Range, and Premium tiers.
+          </li>
+          <li>
+            <span className="font-semibold">No Account Needed:</span> Everything is available without logging in—just browse and click.
+          </li>
+        </ol>
+      </div>
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        <strong>Affiliate Disclosure:</strong> We may earn a small commission from purchases made through our links, but it doesn’t affect your price or our recommendations.
+      </p>
+    </section>
+  );
+};
+
+export default AboutPage;

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,20 +9,18 @@ export default function Footer() {
       title: 'Quick Links',
       links: [
         { label: 'Home', href: '/' },
-        { label: 'Deals', href: '/deals' },
         { label: 'Categories', href: '/categories' },
-        { label: 'Blog', href: '/blog' },
         { label: 'About', href: '/about' },
       ]
     },
     {
       title: 'Categories',
       links: [
-        { label: 'Electronics', href: '/electronics' },
-        { label: 'Fashion', href: '/fashion' },
-        { label: 'Home & Garden', href: '/home' },
-        { label: 'Sports', href: '/sports' },
-        { label: 'Books', href: '/books' },
+        { label: 'Electronics', href: '/categories/electronics' },
+        { label: 'Fashion', href: '/categories/fashion' },
+        { label: 'Home & Garden', href: '/categories/home-garden' },
+        { label: 'Sports', href: '/categories/sports' },
+        { label: 'Books', href: '/categories/books' },
       ]
     },
     {
@@ -152,9 +150,9 @@ export default function Footer() {
         {/* Affiliate Disclosure */}
         <div className="mt-8 p-4 bg-slate-800/50 rounded-lg">
           <p className="text-slate-400 text-sm text-center leading-relaxed">
-            <strong>Affiliate Disclosure:</strong> Habrio may earn a commission from purchases made through our affiliate links. 
-            This doesn't affect the price you pay or our product recommendations. We only promote products we believe in.
-          </p>
+              <strong>Affiliate Disclosure:</strong> Habrio may earn a commission from purchases made through our affiliate links.
+              This doesn&apos;t affect the price you pay or our product recommendations. We only promote products we believe in.
+            </p>
         </div>
       </div>
     </footer>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import { motion, Variants } from 'framer-motion';
 import {
   ArrowRight,
   Star,
-  TrendingUp,
-  Shield,
+  Users,
+  BookOpen,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -32,9 +33,9 @@ const itemVariants: Variants = {
 
 export default function Hero(): JSX.Element {
   const stats: { icon: LucideIcon; value: string; label: string; color: string }[] = [
-    { icon: Star, value: '4.9/5', label: 'Customer Rating', color: 'text-yellow-500' },
-    { icon: Shield, value: '50K+', label: 'Happy Customers', color: 'text-green-500' },
-    { icon: TrendingUp, value: '70%', label: 'Average Savings', color: 'text-blue-500' },
+    { icon: Star, value: '4.9/5', label: 'User Rating', color: 'text-yellow-500' },
+    { icon: Users, value: '50K+', label: 'Happy Readers', color: 'text-green-500' },
+    { icon: BookOpen, value: '20+', label: 'Buying Guides', color: 'text-blue-500' },
   ];
 
   return (
@@ -56,9 +57,9 @@ export default function Hero(): JSX.Element {
           {/* Badge */}
           <motion.div variants={itemVariants} className="mb-8">
             <div className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-blue-100 to-purple-100 dark:from-blue-900/30 dark:to-purple-900/30 rounded-full border border-blue-200 dark:border-blue-800">
-              <TrendingUp className="mr-2 h-4 w-4 text-blue-600 dark:text-blue-400" />
+              <BookOpen className="mr-2 h-4 w-4 text-blue-600 dark:text-blue-400" />
               <span className="text-sm font-medium text-blue-700 dark:text-blue-300">
-                🔥 Premium Deals Live Now
+                🔥 New Buying Guides Available
               </span>
             </div>
           </motion.div>
@@ -69,11 +70,11 @@ export default function Hero(): JSX.Element {
             className="mb-6 text-5xl font-bold leading-tight md:text-7xl"
           >
             <span className="bg-gradient-to-r from-slate-900 via-blue-800 to-slate-900 bg-clip-text text-transparent dark:from-white dark:via-blue-200 dark:to-white">
-              Discover Premium
+              Discover How to Buy
             </span>
             <br />
             <span className="bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent">
-              Products & Deals
+              the Best Products
             </span>
           </motion.h1>
 
@@ -82,10 +83,10 @@ export default function Hero(): JSX.Element {
             variants={itemVariants}
             className="mx-auto mb-12 max-w-3xl text-xl leading-relaxed text-slate-600 dark:text-slate-300 md:text-2xl"
           >
-            Curated selection of the best products from top brands.
+            Expert tips and step-by-step guides to help you make smart purchasing decisions.
             <br className="hidden md:block" />
             <span className="font-semibold text-slate-700 dark:text-slate-200">
-              Save up to 70% with exclusive deals
+              Shop smarter, buy with confidence.
             </span>
           </motion.p>
 
@@ -99,10 +100,10 @@ export default function Hero(): JSX.Element {
               whileTap={{ scale: 0.95 }}
               className="group rounded-2xl bg-gradient-to-r from-blue-600 to-purple-600 px-8 py-4 text-lg font-semibold text-white shadow-lg transition-all duration-300 hover:shadow-xl"
             >
-              <span className="flex items-center">
-                Browse All Deals
+              <Link href="/categories" className="flex items-center">
+                Browse Guides
                 <ArrowRight className="ml-2 h-5 w-5 transition-transform duration-200 group-hover:translate-x-1" />
-              </span>
+              </Link>
             </motion.button>
 
             <motion.button
@@ -110,7 +111,7 @@ export default function Hero(): JSX.Element {
               whileTap={{ scale: 0.95 }}
               className="rounded-2xl border border-slate-200 bg-white/10 px-8 py-4 text-lg font-semibold text-slate-700 backdrop-blur-sm transition-all duration-300 hover:bg-white/20 dark:border-slate-700 dark:bg-slate-800/20 dark:text-slate-300 dark:hover:bg-slate-800/30"
             >
-              How It Works
+              <Link href="/about">How It Works</Link>
             </motion.button>
           </motion.div>
 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Search, Menu, X, Sun, Moon, ShoppingBag } from 'lucide-react';
 import { useTheme } from './ThemeProvider';
@@ -72,15 +73,19 @@ export default function Navigation() {
 
             {/* Desktop Navigation */}
             <div className="hidden md:flex items-center space-x-8">
-              {['Home', 'Deals', 'Categories', 'Blog', 'About'].map((item) => (
-                <motion.a
-                  key={item}
-                  href={`#${item.toLowerCase()}`}
-                  whileHover={{ y: -2 }}
-                  className="text-slate-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-200 font-medium"
-                >
-                  {item}
-                </motion.a>
+              {[
+                { label: 'Home', href: '/' },
+                { label: 'Categories', href: '/categories' },
+                { label: 'About', href: '/about' },
+              ].map((item) => (
+                <motion.div key={item.label} whileHover={{ y: -2 }}>
+                  <Link
+                    href={item.href}
+                    className="text-slate-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-200 font-medium"
+                  >
+                    {item.label}
+                  </Link>
+                </motion.div>
               ))}
             </div>
 
@@ -139,15 +144,19 @@ export default function Navigation() {
                   className="w-full pl-10 pr-4 py-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
               </div>
-              {['Home', 'Deals', 'Categories', 'Blog', 'About'].map((item) => (
-                <a
-                  key={item}
-                  href={`#${item.toLowerCase()}`}
+              {[
+                { label: 'Home', href: '/' },
+                { label: 'Categories', href: '/categories' },
+                { label: 'About', href: '/about' },
+              ].map((item) => (
+                <Link
+                  key={item.label}
+                  href={item.href}
                   className="block text-slate-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-200 font-medium py-2"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
-                  {item}
-                </a>
+                  {item.label}
+                </Link>
               ))}
             </div>
           </motion.div>

--- a/components/Newsletter.tsx
+++ b/components/Newsletter.tsx
@@ -37,7 +37,7 @@ export default function Newsletter() {
             Welcome to Habrio! 🎉
           </h3>
           <p className="text-slate-600 dark:text-slate-400">
-            You're all set! We'll keep you updated with the best deals and exclusive offers.
+            You&apos;re all set! We&apos;ll keep you updated with the best deals and exclusive offers.
           </p>
         </motion.div>
       </section>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,47 @@
+export const categories = [
+  { name: 'Electronics', slug: 'electronics', description: 'Devices, gadgets and tech products' },
+  { name: 'Fashion', slug: 'fashion', description: 'Clothing, apparel, and style accessories' },
+  { name: 'Home & Garden', slug: 'home-garden', description: 'Home appliances, furniture, and garden tools' },
+  { name: 'Sports', slug: 'sports', description: 'Fitness, sports gear, and outdoor equipment' },
+  { name: 'Books', slug: 'books', description: 'Literature, learning, and entertainment books' }
+];
+
+export const guides = [
+  {
+    title: 'How to Buy a Laptop',
+    slug: 'laptop',
+    category: 'electronics',
+    product: 'Laptop',
+    excerpt: 'Learn the key factors to consider when choosing a new laptop.'
+  },
+  {
+    title: 'How to Buy Running Shoes',
+    slug: 'running-shoes',
+    category: 'fashion',
+    product: 'Running Shoes',
+    excerpt: 'Discover what to look for in quality running footwear for any budget.'
+  },
+  {
+    title: 'How to Buy an Air Conditioner',
+    slug: 'air-conditioner',
+    category: 'home-garden',
+    product: 'Air Conditioner',
+    excerpt: 'Understand important criteria (capacity, efficiency, etc.) for AC units.'
+  },
+  {
+    title: 'How to Buy a Treadmill',
+    slug: 'treadmill',
+    category: 'sports',
+    product: 'Treadmill',
+    excerpt: 'Key features to consider when purchasing a home treadmill for exercise.'
+  },
+  {
+    title: 'How to Buy Books Online',
+    slug: 'buy-books-online',
+    category: 'books',
+    product: 'Books',
+    excerpt: 'Tips for finding great books and deals when shopping online.'
+  }
+];
+
+export { categories, guides };


### PR DESCRIPTION
## Summary
- switch navigation and footer to Home, Categories, and About pages
- centralize categories and guides data
- rewrite hero section and add About page for buying guides theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0955a89e88333886cb987bb0813e2