### PR TITLE
Add categories overview and remove deals sections

### DIFF
--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,20 +1,18 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import Hero from '@/components/Hero';
-import Newsletter from '@/components/Newsletter';
+import CategoryGrid from '@/components/CategoryGrid';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
-import CategoryGrid from '@/components/CategoryGrid';
+import Newsletter from '@/components/Newsletter';
 
-export default function Home() {
+export default function CategoriesPage() {
   return (
     <ThemeProvider>
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
         <Navigation />
         <main>
-          <Hero />
           <section className="py-20 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
             <motion.div
               initial={{ opacity: 0, y: 30 }}
@@ -23,11 +21,11 @@ export default function Home() {
               viewport={{ once: true }}
               className="text-center mb-12"
             >
-              <h2 className="text-4xl font-bold mb-4 bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent dark:from-white dark:to-slate-300">
-                Browse Categories
-              </h2>
+              <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent dark:from-white dark:to-slate-300">
+                All Categories
+              </h1>
               <p className="text-xl text-slate-600 dark:text-slate-400">
-                Explore our guide categories and find the products you need help with
+                Browse all product categories below. Select a category to see buying guides.
               </p>
             </motion.div>
             <CategoryGrid />

--- a/components/CategoryGrid.tsx
+++ b/components/CategoryGrid.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { categories } from '@/lib/data';
+
+function CategoryGrid() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+      {categories.map((cat, index) => (
+        <motion.div
+          key={cat.slug}
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: index * 0.1 }}
+          viewport={{ once: true }}
+          whileHover={{ y: -5 }}
+          className="group relative p-6 rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-800 shadow hover:shadow-lg transition-all"
+        >
+          <h3 className="text-2xl font-semibold mb-2 text-slate-800 dark:text-slate-100">{cat.name}</h3>
+          {cat.description && (
+            <p className="text-slate-600 dark:text-slate-400 mb-4">{cat.description}</p>
+          )}
+          <Link href={`/categories/${cat.slug}`} className="absolute inset-0 z-10" />
+        </motion.div>
+      ))}
+    </div>
+  );
+}
+
+export default CategoryGrid;


### PR DESCRIPTION
## Summary
- Remove featured deals and product grid from home
- Introduce animated categories section on the home page
- Add reusable `CategoryGrid` and categories index page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b09902c6fc8333a79b4bede2141d62