### PR TITLE
Remove latest posts preview and unify footer usage

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,16 +1,11 @@
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
-import { ThemeProvider } from '@/components/ThemeProvider';
 import Section from '@/components/kit/Section';
 import PageHeader from '@/components/kit/PageHeader';
 import { Card, CardContent } from '@/components/ui/card';
 
 export default function AboutPage() {
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto mt-6">
             <PageHeader title="About Habrio" description="Your trusted companion for smarter shopping." />
             <Card className="rounded-2xl bg-white/70 dark:bg-slate-800/70 backdrop-blur">
@@ -43,9 +38,7 @@ export default function AboutPage() {
               </CardContent>
             </Card>
           </Section>
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }

--- a/app/categories/[category]/[subcategory]/[post]/page.tsx
+++ b/app/categories/[category]/[subcategory]/[post]/page.tsx
@@ -1,6 +1,3 @@
-import { ThemeProvider } from '@/components/ThemeProvider';
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
 import Section from '@/components/kit/Section';
 import PageHeader from '@/components/kit/PageHeader';
 import { notFound } from 'next/navigation';
@@ -45,10 +42,8 @@ export default async function GuidePage({ params }: { params: Promise<Params> })
   }
 
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto mt-6">
             <PageHeader title={blog.title} description={blog.excerpt ?? undefined} />
             {blog.cover_image_path && (
@@ -72,9 +67,7 @@ export default async function GuidePage({ params }: { params: Promise<Params> })
               )}
             </div>
           </Section>
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }

--- a/app/categories/[category]/page.tsx
+++ b/app/categories/[category]/page.tsx
@@ -1,6 +1,3 @@
-import { ThemeProvider } from '@/components/ThemeProvider';
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
 import Newsletter from '@/components/Newsletter';
 import { notFound } from 'next/navigation';
 import PageHeader from '@/components/kit/PageHeader';
@@ -30,10 +27,8 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
   );
 
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-6xl mx-auto mt-6">
             <PageHeader title={category.name} description={category.description ?? undefined} />
 
@@ -46,10 +41,8 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
             )}
           </Section>
           <Newsletter />
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }
 

--- a/app/categories/[category]/sub/[sub]/page.tsx
+++ b/app/categories/[category]/sub/[sub]/page.tsx
@@ -1,6 +1,3 @@
-import { ThemeProvider } from '@/components/ThemeProvider';
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
 import Section from '@/components/kit/Section';
 import PageHeader from '@/components/kit/PageHeader';
 import { fetchCategoryBySlug, fetchSubcategoryBySlugs, fetchGuidesInSubcategory } from '@/lib/queries';
@@ -18,10 +15,8 @@ export default async function SubcategoryPage({ params }: { params: Promise<{ ca
   const guides = await fetchGuidesInSubcategory(category, sub);
 
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto mt-6">
             <PageHeader title={subcat.name} description={`Posts under ${cat.name}`} />
             {guides.length === 0 ? (
@@ -40,10 +35,8 @@ export default async function SubcategoryPage({ params }: { params: Promise<{ ca
               </ul>
             )}
           </Section>
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }
 

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,25 +1,18 @@
 "use client";
 
 import CategoryGrid from '@/components/CategoryGrid';
-import { ThemeProvider } from '@/components/ThemeProvider';
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
 import Section from '@/components/kit/Section';
 import PageHeader from '@/components/kit/PageHeader';
 
 export default function CategoriesPage() {
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto mt-6">
             <PageHeader title="All Categories" description="Browse guide categories and start exploring." className="text-center" />
             <CategoryGrid />
           </Section>
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 // Server Component: keeps UI the same, allows async children
 import Hero from '@/components/Hero';
 import Newsletter from '@/components/Newsletter';
-import PostsPreview from '@/components/PostsPreview';
 import HomeCategoriesServer from '@/components/HomeCategoriesServer';
 
 export default function Home() {
@@ -12,7 +11,6 @@ export default function Home() {
         <section className="py-6 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
           {/* Server-fetched categories from Supabase; UI unchanged */}
           <HomeCategoriesServer />
-          <PostsPreview />
         </section>
 
         <Newsletter />

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,6 +1,3 @@
-import { ThemeProvider } from '@/components/ThemeProvider';
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
 import Section from '@/components/kit/Section';
 import PageHeader from '@/components/kit/PageHeader';
 import { searchBlogs, fetchAllCategoriesMap, fetchAllSubcategoriesMap } from '@/lib/queries';
@@ -47,10 +44,8 @@ export default async function PostsPage({
     }
   }
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto mt-6">
             <PageHeader title={title} description={description} />
             {rows.length === 0 ? (
@@ -79,9 +74,7 @@ export default async function PostsPage({
               </>
             )}
           </Section>
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,15 +1,10 @@
-import { ThemeProvider } from '@/components/ThemeProvider';
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
 import Section from '@/components/kit/Section';
 import PageHeader from '@/components/kit/PageHeader';
 
 export default function PrivacyPage() {
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto">
             <PageHeader title="Privacy Policy" />
             <div className="prose prose-slate dark:prose-invert max-w-none">
@@ -22,10 +17,8 @@ export default function PrivacyPage() {
               <p>For questions, contact us at info@habrio.in.</p>
             </div>
           </Section>
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }
 

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,6 +1,3 @@
-import { ThemeProvider } from '@/components/ThemeProvider';
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
 import Section from '@/components/kit/Section';
 import PageHeader from '@/components/kit/PageHeader';
 import { searchBlogs, fetchAllCategoriesMap, fetchAllSubcategoriesMap } from '@/lib/queries';
@@ -36,10 +33,8 @@ export default async function SearchPage({
   const pages = pageCount(total, pageSize);
 
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto mt-6">
             <PageHeader title="Search" description="Find guides by keywords, category, or subcategory." />
             <SearchForm initialQ={q} initialCategory={category} initialSub={sub} />
@@ -72,9 +67,7 @@ export default async function SearchPage({
               )}
             </section>
           </Section>
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,15 +1,10 @@
-import { ThemeProvider } from '@/components/ThemeProvider';
-import Navigation from '@/components/Navigation';
-import Footer from '@/components/Footer';
 import Section from '@/components/kit/Section';
 import PageHeader from '@/components/kit/PageHeader';
 
 export default function TermsPage() {
   return (
-    <ThemeProvider>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
-        <Navigation />
-        <main>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 transition-all duration-500">
+      <main>
           <Section className="px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto">
             <PageHeader title="Terms of Service" />
             <div className="prose prose-slate dark:prose-invert max-w-none">
@@ -24,10 +19,8 @@ export default function TermsPage() {
               <p>Questions? Email us at info@habrio.in.</p>
             </div>
           </Section>
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+      </main>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove redundant latest posts preview section from the home page
- consolidate footer usage by relying on root layout instead of per-page footers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b69c26aa488333a00c215154290279